### PR TITLE
Refactor message/markdown.clj - Planning to replace it with core.clj & tranform.clj

### DIFF
--- a/src/co/gaiwan/message/core.clj
+++ b/src/co/gaiwan/message/core.clj
@@ -59,8 +59,8 @@
   (map
    (fn [[type content :as token]]
      (if (= :emoji type)
-       [:emoji (or (text->emoji content emoji-map)
-                   (str ":" content ":"))]
+       [:span.emoji (or (text->emoji content emoji-map)
+                        (str ":" content ":"))]
        token))
    message))
 

--- a/src/co/gaiwan/message/transform.clj
+++ b/src/co/gaiwan/message/transform.clj
@@ -27,7 +27,7 @@
 
 (defn- transform-emoji
   [content]
-  [:span.emoji content])
+  [:emoji content])
 
 (defn- transform-bold
   [content]

--- a/test/co/gaiwan/message/core_test.clj
+++ b/test/co/gaiwan/message/core_test.clj
@@ -21,7 +21,84 @@
                     " "
                     [:span.username
                      [:a {:href "https://someteam.slack.com/team/U4F2A0Z9HR"} "@" "Marry"]])]
-             (markdown/message->hiccup "Hey <@U4F2A0Z8ER> <@U4F2A0Z9HR>" {"U4F2A0Z8ER" "John" "U4F2A0Z9HR" "Marry"}))))))
+             (markdown/message->hiccup "Hey <@U4F2A0Z8ER> <@U4F2A0Z9HR>" {"U4F2A0Z8ER" "John" "U4F2A0Z9HR" "Marry"})))
+      (is (=
+           [:p
+            (list [:b
+                   "Hey everyone, we’re so excited to be here for DevOps Enterprise Summit talking about"]
+                  "\n"
+                  [:span.emoji "➡️"]
+                  " "
+                  [:i
+                   [:b
+                    (list "Be sure to visit our booth "
+                          [:a
+                           {:href "https://doesvirtual.com/teamform"}
+                           "https://doesvirtual.com/teamform"])]]
+                  " \n"
+                  [:span.emoji "📺"]
+                  " "
+                  [:i
+                   [:b
+                    (list "Or join us anytime on Zoom - "
+                          [:a {:href "https://bit.ly/3iIdX1X"} "https://bit.ly/3iIdX1X"])]]
+                  "\n"
+                  [:span.emoji "📣"]
+                  " "
+                  [:i
+                   [:b
+                    (list "Schedule a private demo - "
+                          [:a
+                           {:href "https://teamform.co/demo"}
+                           "https://teamform.co/demo"])]]
+                  "\n"
+                  [:span.emoji "🎁"]
+                  " "
+                  [:i
+                   [:b
+                    (list "Register for giveaway (1x PS5 or XBox Series X, 1 x 50min chat with the authors of Team Topologies, 20x IT Rev Books) "
+                          [:a
+                           {:href "https://www.teamform.co/does-giveaway"}
+                           "https://www.teamform.co/does-giveaway"])]]
+                  "\n\n"
+                  [:b
+                   "We’ve got a exciting week with a bunch of demos of TeamForm scheduled"]
+                  "\n"
+                  [:span.emoji "⭐"]
+                  " 11-11:15am PDT: TeamForm Live Demo: Managing Supply & Demand at Scale - join @ "
+                  [:a
+                   {:href "https://us02web.zoom.us/j/81956904920"}
+                   "https://us02web.zoom.us/j/81956904920"]
+                  "\n"
+                  [:span.emoji "⭐"]
+                  " 12:45-1:00pm PDT: TeamForm Live Demo: Measuring Team Organising Principles - join @ "
+                  [:a
+                   {:href "https://us02web.zoom.us/j/81956904920"}
+                   "https://us02web.zoom.us/j/81956904920"]
+                  "\n"
+                  [:span.emoji "📊"]
+                  " 3:45-4pm PDT: TeamForm Live Demo: Measuring Team Proficiency - join @ "
+                  [:a
+                   {:href "https://us02web.zoom.us/j/81956904920"}
+                   "https://us02web.zoom.us/j/81956904920"]
+                  "\n\nLater this week:\n"
+                  [:span.emoji "➡️"]
+                  " Register for our AMA with Authors of TeamTopologies "
+                  [:a {:href "https://sched.co/ej42"} "https://sched.co/ej42"]
+                  " with "
+                  [:span.username
+                   [:a
+                    {:href "https://someteam.slack.com/team/ULTTZCP7S"}
+                    "@"
+                    "ULTTZCP7S"]]
+                  " & "
+                  [:span.username
+                   [:a
+                    {:href "https://someteam.slack.com/team/UBE001UAX"}
+                    "@"
+                    "UBE001UAX"]])]
+           (markdown/message->hiccup
+            "*Hey everyone, we\u2019re so excited to be here for DevOps Enterprise Summit talking about*\n:arrow_right: _*Be sure to visit our booth <https://doesvirtual.com/teamform>*_ \n:tv: _*Or join us anytime on Zoom -\u00a0<https://bit.ly/3iIdX1X>*_\n:mega: _*Schedule a private demo - <https://teamform.co/demo>*_\n:gift: _*Register for giveaway (1x PS5 or XBox Series X, 1 x 50min chat with the authors of Team Topologies, 20x IT Rev Books) <https://www.teamform.co/does-giveaway>*_\n\n*We\u2019ve got a exciting week with a bunch of demos of TeamForm scheduled*\n:star: 11-11:15am PDT: TeamForm Live Demo: Managing Supply &amp; Demand at Scale - join @ <https://us02web.zoom.us/j/81956904920>\n:star: 12:45-1:00pm PDT: TeamForm Live Demo: Measuring Team Organising Principles - join @ <https://us02web.zoom.us/j/81956904920>\n:bar_chart: 3:45-4pm PDT: TeamForm Live Demo: Measuring Team Proficiency - join @ <https://us02web.zoom.us/j/81956904920>\n\nLater this week:\n:arrow_right: Register for our AMA with Authors of TeamTopologies <https://sched.co/ej42> with <@ULTTZCP7S> &amp; <@UBE001UAX>" nil))))))
 
 (deftest markdown-utilities
   (testing "extract-user-ids"

--- a/test/co/gaiwan/message/markdown_test.clj
+++ b/test/co/gaiwan/message/markdown_test.clj
@@ -21,7 +21,84 @@
                     " "
                     [:span.username
                      [:a {:href "https://someteam.slack.com/team/U4F2A0Z9HR"} "@" "Marry"]])]
-             (markdown/message->hiccup "Hey <@U4F2A0Z8ER> <@U4F2A0Z9HR>" {"U4F2A0Z8ER" "John" "U4F2A0Z9HR" "Marry"}))))))
+             (markdown/message->hiccup "Hey <@U4F2A0Z8ER> <@U4F2A0Z9HR>" {"U4F2A0Z8ER" "John" "U4F2A0Z9HR" "Marry"})))
+      (is (=
+           [:p
+            (list [:b
+                   "Hey everyone, we’re so excited to be here for DevOps Enterprise Summit talking about"]
+                  "\n"
+                  [:span.emoji "➡️"]
+                  " "
+                  [:i
+                   [:b
+                    (list "Be sure to visit our booth "
+                          [:a
+                           {:href "https://doesvirtual.com/teamform"}
+                           "https://doesvirtual.com/teamform"])]]
+                  " \n"
+                  [:span.emoji "📺"]
+                  " "
+                  [:i
+                   [:b
+                    (list "Or join us anytime on Zoom - "
+                          [:a {:href "https://bit.ly/3iIdX1X"} "https://bit.ly/3iIdX1X"])]]
+                  "\n"
+                  [:span.emoji "📣"]
+                  " "
+                  [:i
+                   [:b
+                    (list "Schedule a private demo - "
+                          [:a
+                           {:href "https://teamform.co/demo"}
+                           "https://teamform.co/demo"])]]
+                  "\n"
+                  [:span.emoji "🎁"]
+                  " "
+                  [:i
+                   [:b
+                    (list "Register for giveaway (1x PS5 or XBox Series X, 1 x 50min chat with the authors of Team Topologies, 20x IT Rev Books) "
+                          [:a
+                           {:href "https://www.teamform.co/does-giveaway"}
+                           "https://www.teamform.co/does-giveaway"])]]
+                  "\n\n"
+                  [:b
+                   "We’ve got a exciting week with a bunch of demos of TeamForm scheduled"]
+                  "\n"
+                  [:span.emoji "⭐"]
+                  " 11-11:15am PDT: TeamForm Live Demo: Managing Supply & Demand at Scale - join @ "
+                  [:a
+                   {:href "https://us02web.zoom.us/j/81956904920"}
+                   "https://us02web.zoom.us/j/81956904920"]
+                  "\n"
+                  [:span.emoji "⭐"]
+                  " 12:45-1:00pm PDT: TeamForm Live Demo: Measuring Team Organising Principles - join @ "
+                  [:a
+                   {:href "https://us02web.zoom.us/j/81956904920"}
+                   "https://us02web.zoom.us/j/81956904920"]
+                  "\n"
+                  [:span.emoji "📊"]
+                  " 3:45-4pm PDT: TeamForm Live Demo: Measuring Team Proficiency - join @ "
+                  [:a
+                   {:href "https://us02web.zoom.us/j/81956904920"}
+                   "https://us02web.zoom.us/j/81956904920"]
+                  "\n\nLater this week:\n"
+                  [:span.emoji "➡️"]
+                  " Register for our AMA with Authors of TeamTopologies "
+                  [:a {:href "https://sched.co/ej42"} "https://sched.co/ej42"]
+                  " with "
+                  [:span.username
+                   [:a
+                    {:href "https://someteam.slack.com/team/ULTTZCP7S"}
+                    "@"
+                    "ULTTZCP7S"]]
+                  " & "
+                  [:span.username
+                   [:a
+                    {:href "https://someteam.slack.com/team/UBE001UAX"}
+                    "@"
+                    "UBE001UAX"]])]
+           (markdown/message->hiccup
+            "*Hey everyone, we\u2019re so excited to be here for DevOps Enterprise Summit talking about*\n:arrow_right: _*Be sure to visit our booth <https://doesvirtual.com/teamform>*_ \n:tv: _*Or join us anytime on Zoom -\u00a0<https://bit.ly/3iIdX1X>*_\n:mega: _*Schedule a private demo - <https://teamform.co/demo>*_\n:gift: _*Register for giveaway (1x PS5 or XBox Series X, 1 x 50min chat with the authors of Team Topologies, 20x IT Rev Books) <https://www.teamform.co/does-giveaway>*_\n\n*We\u2019ve got a exciting week with a bunch of demos of TeamForm scheduled*\n:star: 11-11:15am PDT: TeamForm Live Demo: Managing Supply &amp; Demand at Scale - join @ <https://us02web.zoom.us/j/81956904920>\n:star: 12:45-1:00pm PDT: TeamForm Live Demo: Measuring Team Organising Principles - join @ <https://us02web.zoom.us/j/81956904920>\n:bar_chart: 3:45-4pm PDT: TeamForm Live Demo: Measuring Team Proficiency - join @ <https://us02web.zoom.us/j/81956904920>\n\nLater this week:\n:arrow_right: Register for our AMA with Authors of TeamTopologies <https://sched.co/ej42> with <@ULTTZCP7S> &amp; <@UBE001UAX>" nil))))))
 
 (deftest markdown-utilities
   (testing "extract-user-ids"


### PR DESCRIPTION
I found there are some inconsistent and duplicated implementation in `message/markdown.clj`, for example:
- `replace-ids-names` is using `postwalk`, but `segments->hiccup`  is using hand-written recursive processing
- Both `replace-ids-names` and `segments->hiccup` touch the `[:user-id xxxx]` vector, which is unnecessary. We should merge the two operations. 

I have done:
- [x] Pull out the `segments->hiccup` to a new namespace `transform`. 
- [x] At `transform` namespace, rewrite the hand-written recursive with a `postwalk` version 
- [x] Pull out the `:user-id` handling logic from `segments->hiccup`, and put it into the `replace-ids-names`. This will make fixing the hardcoded part much more easier.
- [x] Changing the processing sequence. Originally, `message -> parsed -> replace user id -> replace emoji id -> hiccup`. Now, it changed to `message -> parsed -> hiccup -> replace user id -> replace emoji id`  
- [x] Prepare a test file `message/core_test.clj`, which is the corresponding version of the `message/markdown_test.clj`