### PR TITLE
[Hold on] create a parser based on clj-antlr

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,7 @@
   org.clojure/data.json    {:mvn/version "1.0.0"}
   hiccup/hiccup            {:mvn/version "2.0.0-alpha2"}
   lambdaisland/uri         {:mvn/version "1.4.54"}
+  clj-antlr/clj-antlr      {:mvn/version "0.2.9"}
 
   ;; Http
   hato/hato                {:mvn/version "0.8.0"}

--- a/resources/markdown.g4
+++ b/resources/markdown.g4
@@ -1,0 +1,11 @@
+grammar markdown;
+
+source: token+ ;
+
+token: italic | bold | undecorated ;
+
+italic: '_' token* '_' ;
+
+bold: '*' token* '*' ;
+
+undecorated: 'b'+ ;

--- a/src/co/gaiwan/message/parser.clj
+++ b/src/co/gaiwan/message/parser.clj
@@ -1,0 +1,7 @@
+(ns co.gaiwan.message.parser
+  (:require [clj-antlr.core :as antlr]
+            [clojure.java.io :as io]))
+
+(def parse (antlr/parser (slurp (io/resource "markdown.g4"))))
+
+(time (parse "_*bbb*_"))


### PR DESCRIPTION
According to [here](https://github.com/aphyr/clj-antlr#faster), I think a parser created by `clj-antlr` is possibly to be faster and flexible. However, there are several things we need to do to achieve that. 

- [ ] write down a first workable ANTLR grammar for slack-markdown.
- [ ] make sure that the clj-antlr parse is fast enough to justify its value. 
- [ ] transform the ANTLR syntax tree to the INSTAPARSE syntax tree (hiccup-tree). 
 
Reference: 
[ANTLR tutorial ](https://tomassetti.me/antlr-mega-tutorial/)