### PR TITLE
fix slack error checking

### DIFF
--- a/src/co/gaiwan/slack/api.clj
+++ b/src/co/gaiwan/slack/api.clj
@@ -65,19 +65,4 @@
   [conn channel-id]
   (conversations-join conn {:channel channel-id}))
 
-(defn error?
-  "Is the response an error?
-
-  This checks for a couple of different cases that might arise. Generally it's
-  advisable to always check if a response is an error before trying to use its
-  results.
-
-  Slack returns an :ok true/false key in every response. For paginated
-  collection responses we normally unwrap the outer map, unless (= :ok false),
-  so this should also work on collection responses.
-
-  For rare exceptions where Slack returns a non-200 response with an empty body
-  we simply return `:error`."
-  [response]
-  (or (= :error response)
-      (and (map? response) (false? (:ok response)))))
+(def error? web/error?)

--- a/src/co/gaiwan/slack/api/web.clj
+++ b/src/co/gaiwan/slack/api/web.clj
@@ -39,7 +39,7 @@
   we simply return `:error`."
   [response]
   (or (= :error response)
-      (and (map? response) (false? (:ok response)))))
+      (and (map? response) (false? (or (:ok response) (get response "ok"))))))
 
 (defn- send-get-request
   "Sends a GET http request with formatted params.


### PR DESCRIPTION
we aren't keywordizing slack responses so error check was failing